### PR TITLE
WIP: Generate Spack resource statements

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"path"
 	"text/template"
 
+	"github.com/dmgk/modules2tuple/spack"
 	"github.com/dmgk/modules2tuple/tuple"
 )
 
@@ -28,7 +29,16 @@ func main() {
 	parser := tuple.NewParser(flagPackagePrefix, flagOffline)
 	tuples, errors := parser.Load(args[0])
 	if len(tuples) != 0 {
-		fmt.Println(tuples)
+		if !flagSpack {
+			fmt.Println(tuples)
+		} else {
+			resources, err := spack.Resources(flagAppVersion, tuples)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, err.Error())
+				os.Exit(1)
+			}
+			fmt.Println(resources)
+		}
 	}
 	if errors != nil {
 		fmt.Println(errors)
@@ -53,7 +63,9 @@ this commit ID translation can be disabled with -offline flag.
 
 var (
 	flagOffline       = false
+	flagSpack         = false
 	flagPackagePrefix = "vendor"
+	flagAppVersion    = ""
 	flagVersion       = false
 )
 
@@ -63,7 +75,9 @@ func init() {
 	basename := path.Base(os.Args[0])
 
 	flag.BoolVar(&flagOffline, "offline", flagOffline, "disable network access")
+	flag.BoolVar(&flagSpack, "spack", flagSpack, "print Spack resource stanzas")
 	flag.StringVar(&flagPackagePrefix, "prefix", "vendor", "package prefix")
+	flag.StringVar(&flagAppVersion, "app_version", "", "application version (for spack)")
 	flag.BoolVar(&flagVersion, "v", flagVersion, "show version")
 
 	flag.Usage = func() {

--- a/spack/resource.go
+++ b/spack/resource.go
@@ -1,0 +1,87 @@
+package spack
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"regexp"
+	"text/template"
+
+	"github.com/hartzell/modules2tuple/tuple"
+)
+
+type resource struct {
+	AppVersion   string
+	Name         string
+	RepoURL      string
+	Fetcher      string
+	CommitIdType string
+	CommitId     string
+	Placement    string
+}
+
+func Resources(appVersion string, tt tuple.Tuples) (string, error) {
+	buf := bytes.Buffer{}
+	for _, t := range tt {
+		r, err := Resource(appVersion, t)
+		if err != nil {
+			return "", err
+		}
+		buf.WriteString(r)
+	}
+	return buf.String(), nil
+}
+
+func Resource(appVersion string, t *tuple.Tuple) (string, error) {
+	var repoSite string
+	var repoURL string
+	var fetcher = "git"
+
+	st := reflect.TypeOf(t.Source)
+	switch st.String() {
+	case "tuple.GH":
+		repoSite = "https://github.com" // tuple.GH.Site() returns ""...
+		repoURL = fmt.Sprintf("%s/%s/%s", repoSite, t.Account, t.Project)
+	case "tuple.GL":
+		repoSite = t.Source.Site()
+		repoURL = fmt.Sprintf("%s/%s/%s", repoSite, t.Account, t.Project)
+	default:
+		return "", fmt.Errorf("Unknown site type: %s", st.String())
+	}
+
+	commitIdType := "tag"
+	commitId := t.Tag
+	matched, err := regexp.MatchString("[0-9a-f]{12}", t.Tag)
+	if err != nil {
+		return "", err
+	}
+	if matched {
+		commitIdType = "commit"
+		// commitId = commitId[:7]
+	}
+
+	var buf bytes.Buffer
+	r := resource{
+		AppVersion:   appVersion,
+		Name:         t.Package,
+		RepoURL:      repoURL,
+		Fetcher:      fetcher,
+		CommitIdType: commitIdType,
+		CommitId:     commitId,
+		Placement:    fmt.Sprintf("%s/%s", t.Prefix, t.Package),
+	}
+	resource_template := `
+    resource(name="{{.Name}}",
+             {{.Fetcher}}="{{.RepoURL}}",
+             {{.CommitIdType}}="{{.CommitId}}",
+             destination=".",{{if .AppVersion}}
+             when="@{{.AppVersion}}",{{end}}
+             placement="{{.Placement}}")`
+	templ := template.Must(template.New("resource").Parse(resource_template))
+	err = templ.Execute(&buf, r)
+	if err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
+}

--- a/spack/resource_test.go
+++ b/spack/resource_test.go
@@ -1,0 +1,83 @@
+package spack
+
+import (
+	"testing"
+
+	"github.com/hartzell/modules2tuple/tuple"
+)
+
+// ExpectedError should only occur if regexp match fails or template
+// execution fails.  I haven't figured out how to test those cases.
+type testCase struct {
+	AppVersion    string
+	Tuple         *tuple.Tuple
+	Expected      string
+	ExpectedError string
+}
+
+// TestResource tests that an input tuple generates the expected
+// resource string.
+func TestResource(t *testing.T) {
+	testCases := []testCase{
+		// This should use "commit"
+		{AppVersion: "1.2.3",
+			Tuple: tParse("github.com/pkg/errors v1.2.3-20150716171945-2caba252f4dc"),
+			Expected: `
+    resource(name="github.com/pkg/errors",
+             git="https://github.com/pkg/errors",
+             commit="2caba252f4dc",
+             destination=".",
+             when="@1.2.3",
+             placement="vendor/github.com/pkg/errors")`,
+			ExpectedError: "",
+		},
+		// This should use "tag"
+		{AppVersion: "1.2.3",
+			Tuple: tParse("github.com/rogpeppe/go-internal v1.3.0"),
+			Expected: `
+    resource(name="github.com/rogpeppe/go-internal",
+             git="https://github.com/rogpeppe/go-internal",
+             tag="v1.3.0",
+             destination=".",
+             when="@1.2.3",
+             placement="vendor/github.com/rogpeppe/go-internal")`,
+			ExpectedError: "",
+		},
+		// empty AppVersion => no when
+		{AppVersion: "",
+			Tuple: tParse("github.com/rogpeppe/go-internal v1.3.0"),
+			Expected: `
+    resource(name="github.com/rogpeppe/go-internal",
+             git="https://github.com/rogpeppe/go-internal",
+             tag="v1.3.0",
+             destination=".",
+             placement="vendor/github.com/rogpeppe/go-internal")`,
+			ExpectedError: "",
+		},
+	}
+	for _, c := range testCases {
+		r, err := Resource(c.AppVersion, c.Tuple)
+		if err != nil {
+			if err.Error() != c.ExpectedError {
+				t.Error(err)
+			}
+		}
+		if c.ExpectedError != "" {
+			t.Errorf("Did not get expected error: %s", c.ExpectedError)
+		}
+		if r != c.Expected {
+			t.Errorf("Got: %s, expected %s", r, c.Expected)
+		}
+	}
+}
+
+// tParse is a helper function that parses a tuple string and returns
+// the resulting *tuple.Tuple.  It panics if there's a problem parsing
+// the string, since that's not what we're testing here.
+func tParse(t string) *tuple.Tuple {
+	tuple, err := tuple.Parse(t, "vendor")
+	if err != nil {
+		panic(err)
+	}
+	return tuple
+}


### PR DESCRIPTION
This is a work in progress, not ready to be merged.  It might change with feedback from @dmgk and/or the Spack community.

---

This adds support for generating [Spack resource statements](https://spack.readthedocs.io/en/latest/packaging_guide.html#resources-expanding-extra-tarballs), in support of [adding general support for Go applications to Spack](https://github.com/spack/spack/issues/13023).  It:

- adds two command line switches (`-spack` and `-app_version`)
- prints Spack resource statements to stdout when `-spack` is provided on the command line, including a `when=...` attribute if `-app_version` is provided.
- includes tests for general functionality, the inclusion of the `when=` attribute, and differentiating between the `commit=` and `tag=` commit depending on the format of the version identifier.

Closes #7