### PR TITLE
Add entry for google.golang.org/protobuf

### DIFF
--- a/tuple/resolver.go
+++ b/tuple/resolver.go
@@ -107,6 +107,7 @@ var resolvers = map[string]resolver{
 	"google.golang.org/appengine": &mirror{GH, "golang", "appengine", ""},
 	"google.golang.org/genproto":  &mirror{GH, "google", "go-genproto", ""},
 	"google.golang.org/grpc":      &mirror{GH, "grpc", "grpc-go", ""},
+	"google.golang.org/protobuf":  &mirror{GH, "protocolbuffers", "protobuf-go", ""},
 	"gopkg.in":                    mirrorFn(gopkgInResolver),
 	"gotest.tools":                mirrorFn(gotestToolsResolver),
 	"honnef.co/go/tools":          &mirror{GH, "dominikh", "go-tools", ""},


### PR DESCRIPTION
Seen with sysutils/gotop (https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=247049)
```
# Mirrors for the following packages are not currently known, please look them up and handle these tuples manually:
#       ::v1.21.0:group_name/vendor/google.golang.org/protobuf
protocolbuffers:protobuf-go:v1.21.0:protocolbuffers_protobuf_go/vendor/google.golang.org/protobuf
```

According to https://pkg.go.dev/mod/google.golang.org/protobuf@v1.24.0
the repo is here: Repository: https://github.com/protocolbuffers/protobuf-go
