### PR TITLE
Add entry for golang.zx2c4.com/wireguard

### DIFF
--- a/tuple/resolver.go
+++ b/tuple/resolver.go
@@ -103,6 +103,7 @@ var resolvers = map[string]resolver{
 	"go4.org":                     &mirror{GH, "go4org", "go4", ""},
 	"gocloud.dev":                 &mirror{GH, "google", "go-cloud", ""},
 	"golang.org":                  mirrorFn(golangOrgResolver),
+	"golang.zx2c4.com/wireguard":  &mirror{GH, "wireguard", "wireguard-go", ""},
 	"google.golang.org/api":       &mirror{GH, "googleapis", "google-api-go-client", ""},
 	"google.golang.org/appengine": &mirror{GH, "golang", "appengine", ""},
 	"google.golang.org/genproto":  &mirror{GH, "google", "go-genproto", ""},


### PR DESCRIPTION
seen with net/yggdrasil: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=247045
```
 # Mirrors for the following packages are not currently known, please look them up and handle these tuples manually:
#       ::v0.0.20200320:group_name/vendor/golang.zx2c4.com/wireguard (from git.zx2c4.com/wireguard-go@v0.0.20200320)
#       ::v0.1.0:group_name/vendor/golang.zx2c4.com/wireguard/windows (from git.zx2c4.com/wireguard-windows@v0.1.0)
```
https://github.com/WireGuard/wireguard-go: Mirror only. Official repository is at https://git.zx2c4.com/wireguard-go