### PR TITLE
If tag is not found as-is, try prepending the path

### DIFF
--- a/apis/github.go
+++ b/apis/github.go
@@ -109,6 +109,17 @@ func GithubLookupTag(account, project, path, tag string) (string, error) {
 		return tag, nil
 	}
 
+	// Try prepending the path to the tag
+	hasTag, err = GithubHasTag(account, project, path+"/"+tag)
+	if err != nil {
+	        return "", err
+	}
+	
+	// tag was found with path prepended
+	if hasTag {
+	        return tag, nil
+	}
+
 	// tag was not found, try to look it up
 	allTags, err := GithubListTags(account, project, tag)
 	if err != nil {


### PR DESCRIPTION
If a repo (like https://github.com/aws/aws-sdk-go-v2) has too many tags, doing a lookup of _all_ tags results in a 502.

In a number of cases I found that the path is actually part of the tag, so we can try that to see if we can find the tag and reduce the number of times we might try getting all tags.