### PR TITLE
Try prepending path to a tag before trying as-is

### DIFF
--- a/apis/github.go
+++ b/apis/github.go
@@ -99,7 +99,18 @@ func GithubListTags(account, project, tag string) ([]string, error) {
 }
 
 func GithubLookupTag(account, project, path, tag string) (string, error) {
-	hasTag, err := GithubHasTag(account, project, tag)
+	// Try prepending the path to the tag
+	hasTag, err := GithubHasTag(account, project, path+"/"+tag)
+	if err != nil {
+	        return "", err
+	}
+
+	// tag was found with path prepended
+	if hasTag {
+	        return path+"/"+tag, nil
+	}
+
+	hasTag, err = GithubHasTag(account, project, tag)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
If a repo (like https://github.com/aws/aws-sdk-go-v2) has too many tags, doing a lookup of _all_ tags results in a 502.

In a number of cases I found that the path is actually part of the tag, so we can try that to see if we can find the tag and reduce the number of times we might try getting all tags.